### PR TITLE
Add SetChatBotTimeout and SetChatBotDebugMode natives + OnChatBotError callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ main()
     SetModel("llama3-70b-8192");
     SetAPIKey(API_KEY);
     SetSystemPrompt("You are an assistant inside GTA SAMP");
+    SetChatBotTimeout(10000);
+    SetChatBotDebugMode(CHATBOT_DEBUG_ERRORS);
 }
 
 CMD:clearmemory(playerid, params[])
@@ -133,6 +135,12 @@ public OnChatBotResponse(prompt[], response[], id)
 
         SendClientMessageToAll(COLOR_MAGENTA, "Chat Bot Responded Globally! Check it with /lastglobalresponse.");
     }
+}
+
+public OnChatBotError(id, const error[])
+{
+    printf("[ChatBot ERROR] | ID: %d | Message: %s", id, error);
+    return 1;
 }
 ```
 ## Installation

--- a/samp-chatbot.inc
+++ b/samp-chatbot.inc
@@ -11,18 +11,18 @@
 #define GB2312		2
 #define W1251		3
 
-enum CHATBOT_DEBUG_MODE
+enum CHATBOT_LOG_MODE
 {
-    CHATBOT_DEBUG_SILENT,
-    CHATBOT_DEBUG_ERRORS,
-    CHATBOT_DEBUG_VERBOSE
+    CHATBOT_LOG_SILENT,
+    CHATBOT_LOG_ERRORS,
+    CHATBOT_LOG_VERBOSE
 };
 
 // Natives
 
 native SetChatBotEncoding(encoding);
 native SetChatBotTimeout(ms);
-native SetChatBotDebugMode(CHATBOT_DEBUG_MODE:mode);
+native SetChatBotLogMode(CHATBOT_LOG_MODE:mode);
 native ClearMemory(id);
 native RequestToChatBot(const prompt[], id);
 native SelectChatBot(type);

--- a/samp-chatbot.inc
+++ b/samp-chatbot.inc
@@ -11,9 +11,18 @@
 #define GB2312		2
 #define W1251		3
 
+enum CHATBOT_DEBUG_MODE
+{
+    CHATBOT_DEBUG_SILENT,
+    CHATBOT_DEBUG_ERRORS,
+    CHATBOT_DEBUG_VERBOSE
+};
+
 // Natives
 
 native SetChatBotEncoding(encoding);
+native SetChatBotTimeout(ms);
+native SetChatBotDebugMode(CHATBOT_DEBUG_MODE:mode);
 native ClearMemory(id);
 native RequestToChatBot(const prompt[], id);
 native SelectChatBot(type);
@@ -25,3 +34,4 @@ native SetModel(const model[]);
 // Callbacks
 
 forward OnChatBotResponse(prompt[], response[], id);
+forward OnChatBotError(id, const error[]);

--- a/src/ChatBotHelper.cpp
+++ b/src/ChatBotHelper.cpp
@@ -146,6 +146,12 @@ bool ChatBotHelper::DoRequest(std::string& response, const std::string request, 
 		curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &curlResponse);
 
+		if (params.timeoutMs > 0)
+		{
+			curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, params.timeoutMs);
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, params.timeoutMs);
+		}
+
 		CURLcode res = curl_easy_perform(curl);
 
 		if (res == CURLE_OK)
@@ -164,13 +170,19 @@ bool ChatBotHelper::DoRequest(std::string& response, const std::string request, 
 				curl_easy_cleanup(curl);
 				curl_slist_free_all(headers);
 
-				logprintf("[ChatBot Plugin]: Request Parsing Failed! Error: %s", exc.what());
+                if (params.debugMode >= 1)
+					logprintf("[ChatBot Plugin]: Request Parsing Failed! Error: %s", exc.what());
+                response = std::string("[ERROR] Request parsing failed: ") + exc.what();
 				
 				return false;
 			}
 		}
 		else
-			logprintf("[ChatBot Plugin]: Failed! Error: %s\n", curl_easy_strerror(res));
+        {
+            if (params.debugMode >= 1)
+                logprintf("[ChatBot Plugin]: Failed! Error: %s\n", curl_easy_strerror(res));
+            response = std::string("[ERROR] ") + curl_easy_strerror(res);
+        }
 
 		curl_easy_cleanup(curl);
 		curl_slist_free_all(headers);
@@ -178,7 +190,9 @@ bool ChatBotHelper::DoRequest(std::string& response, const std::string request, 
 		return res == CURLE_OK;
 	}
 
-	curl_easy_cleanup(curl);
+    curl_easy_cleanup(curl);
+
+    response = "[ERROR] curl init failed";
 
 	return false;
 }
@@ -193,7 +207,24 @@ std::string ChatBotHelper::GetBotAnswer(const ChatBotParams& params, nlohmann::j
 
 			//controllo errori
 			if (response.contains("error"))
-				return response.dump(4).c_str();
+            {
+                try
+                {
+                    std::string errMsg;
+                    if (response["error"].is_string())
+                        errMsg = response.at("error");
+                    else if (response["error"].is_object() && response["error"].contains("message"))
+                        errMsg = response.at("error").at("message");
+                    else
+                        errMsg = response.dump(0);
+
+                    return std::string("[ERROR] ") + errMsg;
+                }
+                catch (...)
+                {
+                    return std::string("[ERROR] ") + response.dump(0);
+                }
+            }
 
 			switch (params.botType)
 			{
@@ -212,10 +243,7 @@ std::string ChatBotHelper::GetBotAnswer(const ChatBotParams& params, nlohmann::j
 		}
 		catch (std::exception &exc)
 		{
-			logprintf("[ChatBot Plugin]: Exception GetBotAnswer(): %s\n", exc.what());
-			logprintf("[ChatBot Plugin]: Exception Response:\n%s", response.dump(4).c_str());
-
-			return response.dump(4).c_str();
+            return std::string("[ERROR] Exception parsing response: ") + exc.what();
 		}
 	}
 

--- a/src/ChatBotHelper.cpp
+++ b/src/ChatBotHelper.cpp
@@ -170,7 +170,7 @@ bool ChatBotHelper::DoRequest(std::string& response, const std::string request, 
 				curl_easy_cleanup(curl);
 				curl_slist_free_all(headers);
 
-                if (params.debugMode >= 1)
+				if (params.logMode >= LOG_ERRORS)
 					logprintf("[ChatBot Plugin]: Request Parsing Failed! Error: %s", exc.what());
                 response = std::string("[ERROR] Request parsing failed: ") + exc.what();
 				
@@ -179,7 +179,7 @@ bool ChatBotHelper::DoRequest(std::string& response, const std::string request, 
 		}
 		else
         {
-            if (params.debugMode >= 1)
+			if (params.logMode >= LOG_ERRORS)
                 logprintf("[ChatBot Plugin]: Failed! Error: %s\n", curl_easy_strerror(res));
             response = std::string("[ERROR] ") + curl_easy_strerror(res);
         }

--- a/src/ChatBotHelper.h
+++ b/src/ChatBotHelper.h
@@ -142,6 +142,8 @@ struct ChatBotParams
 	std::string model;
 	int botType; //enum ChatBots
 	int encoding; //enum Encodings
+	int timeoutMs;
+	int debugMode; // 0: silent, 1: errors. 2: verbose
 };
 
 class ChatBotHelper

--- a/src/ChatBotHelper.h
+++ b/src/ChatBotHelper.h
@@ -17,6 +17,14 @@ enum ChatBots
 	NUM_CHAT_BOTS
 };
 
+enum LogModes
+{
+	LOG_SILENT = 0,
+	LOG_ERRORS,
+	LOG_VERBOSE,
+	NUM_LOG_MODES
+};
+
 class AIRequest
 {
 public:
@@ -55,11 +63,12 @@ private:
 class AIResponse
 {
 public:
-	AIResponse(int id, std::string prompt, std::string response)
+	AIResponse(int id, std::string prompt, std::string response, bool isError = false)
 	{
 		this->id = id;
 		this->prompt = prompt;
 		this->response = response;
+		this->error = isError;
 	}
 
 	std::string GetPrompt()
@@ -77,10 +86,16 @@ public:
 		return this->id;
 	}
 
+	bool IsInError() const
+	{
+		return this->error;
+	}
+
 private:
 	std::string prompt; //prompt from the player
 	std::string response; //response of gpt
 	int id; //ID of the original request
+	bool error;
 };
 
 struct Message
@@ -143,7 +158,7 @@ struct ChatBotParams
 	int botType; //enum ChatBots
 	int encoding; //enum Encodings
 	int timeoutMs;
-	int debugMode; // 0: silent, 1: errors. 2: verbose
+	int logMode; //enum LogModes
 };
 
 class ChatBotHelper


### PR DESCRIPTION
## Summary
This PR improves chatbot control and debugging by adding two new native functions and one new callback.
### New Natives
1. `SetChatBotTimeout(ms)` sets the millisecond timeout for chatbot requests. 15000 ms (15 seconds) is the default.
**Implementation:** makes use of `CURLOPT_CONNECTTIMEOUT_MS` and `CURLOPT_TIMEOUT_MS`.
2. `SetChatBotDebugMode(mode)` modifies the chatbot's debug and logging level.
    - `CHATBOT_DEBUG_SILENT (0)` Absence of logs
    - `CHATBOT_DEBUG_ERRORS (1)` - By default, only log errors
    - `CHATBOT_DEBUG_VERBOSE (2)` - Record every request, response, and error.
  ### New Callback 
  - `OnChatBotError(id, const error[])` Initiated in the event of an error (timeout, connection failure, parsing error, API error).
**Parameters**:
     - `id` - Request ID
     - `error[]` - Error message
   **Note:** All errors are now sent to this callback rather than `OnChatBotResponse`.
## Example of Use (PAWN)
```pawn
main() {
    SetChatBotTimeout(5000); // Configure a 5-second timeout
    SetChatBotDebugMode(CHATBOT_DEBUG_VERBOSE);
{

public OnChatBotError(id, const error[]) {
    printf("[ChatBot Error] ID: %d | %s", id, error);
}
```